### PR TITLE
AutoCompleteField#suggestions leads to invalid selector exceptions

### DIFF
--- a/src/main/java/com/adobe/cq/testing/selenium/pagewidgets/coral/CoralButtonList.java
+++ b/src/main/java/com/adobe/cq/testing/selenium/pagewidgets/coral/CoralButtonList.java
@@ -31,7 +31,7 @@ public final class CoralButtonList extends AEMBaseComponent {
      * @param parent the parent element containing this select list.
      */
     public CoralButtonList(final SelenideElement parent) {
-        super(parent.getSearchCriteria() + " coral-buttonlist");
+        super(parent.getSearchCriteria().replaceAll("/", " ") + " coral-buttonlist");
     }
 
     /**


### PR DESCRIPTION
* Replacing slash with a space as it's semantically equivalent for a CSS selector

Fixes #24
