### PR TITLE
AutoCompleteField#suggestions leads to invalid selector exceptions

### DIFF
--- a/src/main/java/com/adobe/cq/testing/selenium/pagewidgets/coral/CoralButtonList.java
+++ b/src/main/java/com/adobe/cq/testing/selenium/pagewidgets/coral/CoralButtonList.java
@@ -31,7 +31,7 @@ public final class CoralButtonList extends AEMBaseComponent {
      * @param parent the parent element containing this select list.
      */
     public CoralButtonList(final SelenideElement parent) {
-        super(parent.getSearchCriteria().replaceAll("/", " ") + " coral-buttonlist");
+        super(parent.find( "coral-buttonlist"));
     }
 
     /**


### PR DESCRIPTION
* Replacing search path selector build with actual lookup inside the parent. Slash replacing was causing failures for selectors that included valid paths (`name='./parentPath'`)

Fixes #24

